### PR TITLE
Log parse error as a readable string

### DIFF
--- a/server/src/ghcModProcess.ts
+++ b/server/src/ghcModProcess.ts
@@ -76,7 +76,7 @@ export class GhcModProcess {
                 clearTimeout(timer);
             }
             // let parseError = (data) => {
-            //     this.logger.log(data);
+            //     this.logger.log(data.toString());
             // }
             let parseData = (data) => {
                 let lines = data.toString().split(EOL);


### PR DESCRIPTION
This change made more sense before the handling of stderr got commented out.

Seems like error output should be displayed nicely to the user and not commented out like this? I at least found this output helpful to debug why my local version of ghc-mod was not working (turned out I needed cereal < 0.5 due to an unresolved bug in ghc-mod)
