### PR TITLE
Insert type command draft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "6"
+before_script: cd server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - "6"
-before_script: cd server

--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,7 @@
     "contributes": {
         "commands": [{
             "command": "ghcmod.insertType",
-            "title": "Insert Type"
+            "title": "Haskell: Insert Type"
         }],
         "configuration": {
             "type": "object",

--- a/client/package.json
+++ b/client/package.json
@@ -23,10 +23,15 @@
         "Languages"
     ],
     "activationEvents": [
-        "onLanguage:haskell"
+        "onLanguage:haskell",
+        "onCommand:ghcmod.insertType"
     ],
     "main": "./out/src/extension",
     "contributes": {
+        "commands": [{
+            "command": "ghcmod.insertType",
+            "title": "Insert Type"
+        }],
         "configuration": {
             "type": "object",
             "title": "Settings for Haskell projects for ghc-mod",

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,0 +1,32 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import { LanguageClient, RequestType, LanguageClientOptions, ServerOptions, TransportKind, TextDocumentPositionParams } from 'vscode-languageclient';
+
+export module Commands {
+    class InsertTypeMessage implements RequestType<TextDocumentPositionParams,string,void> {
+        constructor() {
+            this.method = "insertType";
+        }
+        method:string;
+    }
+    
+    function insertType(client:LanguageClient, editor:vscode.TextEditor) {
+        let sel = editor.selections[0];
+        
+        let info = TextDocumentPositionParams.create(editor.document.uri.toString(), sel.active);
+        client.sendRequest<TextDocumentPositionParams, string, void>(new InsertTypeMessage(), info).then(type => { 
+            // console.log("received type ", type);
+            let iloc = new vscode.Position(sel.active.line, 0);
+            editor.edit(editBuilder => {
+                let line = editor.document.lineAt(iloc.line);
+                editBuilder.insert(iloc, type.replace(/\s+$/,'') + '\n');
+            });
+        });
+    }
+    
+    export function register(ctx: vscode.ExtensionContext, client:LanguageClient) {
+        let pushReg = (x, y) => ctx.subscriptions.push(vscode.commands.registerTextEditorCommand(x, (ed, e) => y(client, ed)));
+        pushReg('ghcmod.insertType', insertType);
+    }
+}

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -19,12 +19,17 @@ export namespace Commands {
                 return;
             }
 
+            let cleanedType = type
+                .replace(/[ ]+/g,' ') // make multiple spaces unique
+                .replace(/[\r\n]/g,'') // remove all line breaks
+                .replace(/[\r\n\s]+$/,''); // remove trailing whitespaces/line breakes
+
             Logger.log(`received type: ${type}`);
             let positionToInsert = new vscode.Position(selection.active.line, 0);
             editor.edit(editBuilder => {
                 let definitionLine = editor.document.lineAt(positionToInsert.line);
                 let indent = definitionLine.text.substring(0, definitionLine.firstNonWhitespaceCharacterIndex);
-                let typeLine = `${indent}${type.replace(/\s+$/,'')}\n`
+                let typeLine = `${indent}${cleanedType}\n`
                 editBuilder.insert(positionToInsert, typeLine);
             });
         });

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -5,12 +5,14 @@
 'use strict';
 
 import * as path from 'path';
-
-import { ExtensionContext } from 'vscode';
+import { ExtensionContext, workspace } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
 import { Commands } from './commands';
+import { Logger } from './utils/logger'
 
 export function activate(context: ExtensionContext) {
+    setLogLevel();
+    workspace.onDidChangeConfiguration(setLogLevel); 
 
     // The server is implemented in node
     let serverModule = context.asAbsolutePath(path.join('server', 'src', 'server.js'));
@@ -41,6 +43,11 @@ export function activate(context: ExtensionContext) {
     // Push the disposable to the context's subscriptions so that the
     // client can be deactivated on extension deactivation
     context.subscriptions.push(disposable);
-
     Commands.register(context, languageClient);
+}
+
+function setLogLevel() {
+    let config = workspace.getConfiguration('haskell.ghcMod');
+    let logLevel = config.get('logLevel', 'error');
+    Logger.setLogLevel(Logger.LogLevel[logLevel]);
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 
 import { ExtensionContext } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { Commands } from './commands';
 
 export function activate(context: ExtensionContext) {
 
@@ -34,9 +35,12 @@ export function activate(context: ExtensionContext) {
     };
 
     // Create the language client and start the client.
-    let disposable = new LanguageClient('ghc-mod server', serverOptions, clientOptions).start();
+    let languageClient = new LanguageClient('ghc-mod server', serverOptions, clientOptions);
+    let disposable = languageClient.start();
 
     // Push the disposable to the context's subscriptions so that the
     // client can be deactivated on extension deactivation
     context.subscriptions.push(disposable);
+
+    Commands.register(context, languageClient);
 }

--- a/client/src/utils/logger.ts
+++ b/client/src/utils/logger.ts
@@ -1,0 +1,46 @@
+'use strict';
+
+import { window } from 'vscode';
+
+export namespace Logger {
+    export enum LogLevel {
+        none,
+        error,
+        warn,
+        info,
+        log
+    }
+    
+    let logLevel = LogLevel.none;
+
+    export const setLogLevel = function(level: LogLevel) {
+        logLevel = level;
+    }
+
+    // log methods include an optional level argument to allow
+    // overriding the logger logLevel for a specific call.
+    export const log = function(message: string, level?: LogLevel): void {
+        if (logLevel >= LogLevel.log || level >= LogLevel.log) {
+            console.log(message);
+        }
+    }
+
+    export const info = function(message: string, level?: LogLevel): void {
+        if (logLevel >= LogLevel.info || level >= LogLevel.info) {
+            console.info(message);
+        }
+    }
+
+    export const warn = function(message: string, level?: LogLevel): void {
+        if (logLevel >= LogLevel.warn || level >= LogLevel.warn) {
+            console.warn(message);
+        }
+    }
+
+    export const error = function(message: string, level?: LogLevel): void {
+        if (logLevel >= LogLevel.error || level >= LogLevel.error) {
+            console.error(message);
+            window.showErrorMessage(message);
+        }
+    }
+}


### PR DESCRIPTION
Hi,

This commit introduces a new 'Insert Type' command, as seen in Atom haskell plugin.

Sample:
![2016-07-06_15-06-51](https://cloud.githubusercontent.com/assets/1766559/16631140/9730d65a-438b-11e6-8b9a-ee4c858ce0f0.gif)

This is not actually ready for a pull request, but I had to take enough design decisions on my own to think it deserves to be discusses.

I'm using the LanguageClient connection to send custom requests to the server, with then replies with the expected type (surprisingly, this works).

Known Issues:
- bad error handling
- no tests at the moment
- won't prefix the type with the correct indentation

Feel free to discuss it.

Théo
