### PR TITLE
Add Travis settings working for Linux and OS X.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+sudo: required
+dist: trusty
+
+language: node_js
+node_js:
+  - "6"
+
+os:
+  - osx
+  - linux
+
+before_install:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+      sh -e /etc/init.d/xvfb start;
+      sleep 3;
+      sudo apt-get --yes install haskell-platform;
+    else
+      curl "https://downloads.haskell.org/~platform/7.10.3/Haskell%20Platform%207.10.3%2064bit.pkg" -o "x.pkg";
+      sudo installer -pkg x.pkg -target / ;
+    fi
+
+
+install:
+  - ghc --version
+  - cabal --version
+  - cabal update
+  - cabal install ghc-mod
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then 
+      export PATH="/home/travis/.cabal/bin:$PATH";
+    else
+      export PATH="/Users/travis/Library/Haskell/bin:$PATH";
+    fi
+  - cd client
+  - npm install
+  - npm run vscode:prepublish
+  - cd ../server
+  - npm install
+  - npm run compile
+
+script:
+  - npm test

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,3 +1,4 @@
 out
 server
 node_modules
+.vscode-test

--- a/server/test/interactiveGhcMod.spec.ts
+++ b/server/test/interactiveGhcMod.spec.ts
@@ -10,7 +10,7 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import { IGhcMod, GhcModCmdOpts } from '../src/ghcModInterfaces';
-import { TestLogger } from './helpers/TestLogger';
+import { TestLogger } from './helpers/testLogger';
 import { InteractiveGhcModProcess } from '../src/interactiveGhcMod';
 
 // Defines a Mocha test suite to group tests of similar kind together


### PR DESCRIPTION
The OS X build is tricky and takes 27 minutes, but as soon as ghc-mod and it's dependencies will work on GHC 8 we will be able to switch to Homebrew and reduce the build time.
