### PR TITLE
Update readme and add timeout protection to build script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
       sudo apt-get --yes install haskell-platform;
     else
       curl "https://downloads.haskell.org/~platform/7.10.3/Haskell%20Platform%207.10.3%2064bit.pkg" -o "x.pkg";
-      sudo installer -pkg x.pkg -target / ;
+      travis_wait sudo installer -pkg x.pkg -target / ;
     fi
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # vscode-ghc-mod
+Linux, OS X: [![Build Status](https://travis-ci.org/hoovercj/vscode-ghc-mod.svg?branch=master)](https://travis-ci.org/hoovercj/vscode-ghc-mod)
+
 ghc-mod language extension for VS Code.
 
 ## Overview
@@ -35,7 +37,6 @@ From the client directory:
 `vsce publish --ImagesUrl https://raw.githubusercontent.com/hoovercj/vscode-ghc-mod/master/client/`
 
 ## Next steps
-- TODO's before public feedback: https://github.com/hoovercj/vscode-ghc-mod/issues/4
 - Add new commands
 - Add completion backend
 


### PR DESCRIPTION
- Added badge to readme, removed old TODO
- Added timeout porteciton for installer call to prevent build fails [like this one](https://travis-ci.org/hoovercj/vscode-ghc-mod/jobs/149279359)
