### PR TITLE
fix haskell.ghcMod.executablePath default value

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,7 @@
                 },
                 "haskell.ghcMod.executablePath": {
                     "type": "string",
-                    "default": "ghc-mod",
+                    "default": "ghc-modi",
                     "description": "The full path to the ghc-mod executable."
                 },
                 "haskell.ghcMod.onHover": {


### PR DESCRIPTION
Hi

I kept having crashes when installing the extension. I think the default value for the executable should be ghc-modi instead of ghc-mod.

Thanks for the extension!
