### PR TITLE
Fix error on symbol lookup with no provider set

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -152,14 +152,14 @@ function initializeSymbolProvider(): void {
 
     connection.onDocumentSymbol((uri) => {
         if (!symbolProvider || !ghcMod || !ghcModProvider) {
-            return null;
+            return [];
         }
 
         return symbolProvider.getSymbolsForFile(uri);
     });
     connection.onWorkspaceSymbol((query, cancellationToken) => {
         if (!symbolProvider || !ghcMod || !ghcModProvider) {
-            return null;
+            return [];
         }
 
         return symbolProvider.getSymbolsForWorkspace(query, cancellationToken);


### PR DESCRIPTION
If go to symbol was used an error would be thrown inside vscode and logged to the console
because it assumes the returned value is a valid array.