### PR TITLE
Update launch.json to schema version 0.2

### DIFF
--- a/client/.vscode/launch.json
+++ b/client/.vscode/launch.json
@@ -1,6 +1,6 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
 {
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"configurations": [
 		{
 			"name": "Launch Extension",
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/src",
+			"outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out/test",
+			"outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
 			"preLaunchTask": "npm"
 		}
 	]

--- a/server/.vscode/launch.json
+++ b/server/.vscode/launch.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.1.0",
+	"version": "0.2.0",
 	// List of configurations. Add new configurations or edit existing ones.
 	"configurations": [
 		{
@@ -8,7 +8,8 @@
 			"request": "attach",
 			"port": 6004,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/../client/server"
+			"outFiles": [ "${workspaceRoot}/../client/server/**/*.js" ],
+			"protocol": "legacy"
 		}
 	]
 }


### PR DESCRIPTION
I believe this was necessary to get debugging working on my machine. Also
is just a good idea given the language server example project has updated
its launch.json's.

Example project: https://github.com/Microsoft/vscode-languageserver-node-example/blob/master/server/.vscode/launch.json